### PR TITLE
Egyéni szöveg beírása Androidon

### DIFF
--- a/Diatar/src/main/AndroidManifest.xml
+++ b/Diatar/src/main/AndroidManifest.xml
@@ -45,6 +45,11 @@
 		>
 		</activity>
 		<activity
+			android:name=".EdManualText"
+			android:theme="@android:style/Theme.Holo.Light.Dialog"
+			>
+		</activity>
+		<activity
 			android:name=".FileSelectorActivity"
 			android:label="Fájl kiválasztása"
 			android:theme="@android:style/Theme.Holo.Dialog" 

--- a/Diatar/src/main/java/diatar/eu/DiaSaver.java
+++ b/Diatar/src/main/java/diatar/eu/DiaSaver.java
@@ -31,9 +31,10 @@ public class DiaSaver
 						+SaveProp(d.mProps);
 					if (!s.isEmpty()) return s;
 				} else if (d.mTipus==d.ditTXT) {
+					bw.write("caption="+d.mKnev+"\n");
 					bw.write("lines="+d.mTxt.length+"\n");
 					for (int i=0; i<d.mTxt.length; i++) {
-						bw.write("line"+(i+1)+"="+d.mTxt[i]+"\n");
+						bw.write("line"+i+"="+d.mTxt[i]+"\n");
 						String s=SaveProp(d.mProps);
 						if (!s.isEmpty()) return s;
 					}

--- a/Diatar/src/main/java/diatar/eu/EdManualText.java
+++ b/Diatar/src/main/java/diatar/eu/EdManualText.java
@@ -1,0 +1,61 @@
+package diatar.eu;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.EditText;
+
+import androidx.annotation.NonNull;
+
+public class EdManualText extends Activity
+{
+	private EditText mCim;
+	private EditText mTxt;
+
+	@Override
+	protected void onCreate(Bundle bd) {
+		super.onCreate(bd);
+
+		setContentView(R.layout.edmanualtext);
+		setTitle("Szöveg");
+		mCim = findViewById(R.id.edManualTextCim);
+		mTxt = findViewById(R.id.edManualTextSzoveg);
+
+		String knev;
+		String txt;
+		if (bd==null) {
+			Intent it = getIntent();
+			knev=it.getStringExtra(G.idCIM);
+			txt=it.getStringExtra(G.idTXT);
+			if (knev==null) knev = "";
+			if (txt==null) txt = "";
+		} else{
+			knev=bd.getString(G.idCIM);
+			txt=bd.getString(G.idTXT);
+		}
+		mCim.setText(knev);
+		mTxt.setText(txt);
+	}
+	
+	@Override
+	protected void onSaveInstanceState(@NonNull Bundle outState)
+	{
+		super.onSaveInstanceState(outState);
+		outState.putString(G.idCIM,mCim.getText().toString());
+		outState.putString(G.idTXT,mTxt.getText().toString());
+	}
+
+	public void onCancel(View v) {
+		setResult(RESULT_CANCELED);
+		finish();
+	}
+	
+	public void onOk(View v) {
+		Intent it = new Intent();
+		it.putExtra(G.idCIM, mCim.getText().toString());
+		it.putExtra(G.idTXT, mTxt.getText().toString());
+		setResult(RESULT_OK,it);
+		finish();
+	}
+}

--- a/Diatar/src/main/java/diatar/eu/EditActivity.java
+++ b/Diatar/src/main/java/diatar/eu/EditActivity.java
@@ -99,6 +99,8 @@ public class EditActivity extends Activity
 			startActivityForResult(it,REQUEST_ADD_DTX);
 			return true;
 		case R.id.mnEdAddManual:
+			it = new Intent(this, EdManualText.class);
+			startActivityForResult(it,REQUEST_ADD_MANUAL);
 			return true;
 		case R.id.mnEdAddSep:
 			it = new Intent(this, EdSep.class);
@@ -143,8 +145,10 @@ public class EditActivity extends Activity
 		super.onActivityResult(requestCode, resultCode, data);
 		if (requestCode==REQUEST_ADD_SEP) reqAddSep(resultCode, data);
 		if (requestCode==REQUEST_ADD_DTX) reqAddDtx(resultCode, data);
+		if (requestCode==REQUEST_ADD_MANUAL) reqAddManual(resultCode, data);
 		if (requestCode==REQUEST_ADD_PIC) reqAddPic(resultCode, data);
 		if (requestCode==REQUEST_ED_DTX) reqEdDtx(resultCode, data);
+		if (requestCode==REQUEST_ED_MANUAL) reqEdManual(resultCode, data);
 		if (requestCode==REQUEST_ED_SEP) reqEdSep(resultCode, data);
 		if (requestCode==REQUEST_ED_PIC) reqEdPic(resultCode, data);
 		if (requestCode==REQUEST_FILESAVE) reqFilesave(resultCode, data);
@@ -256,6 +260,32 @@ public class EditActivity extends Activity
 		G.sPicDir=dn;
 		G.Save(this);
 	}
+
+	private void reqAddManual(int resultCode, Intent data) {
+		if (resultCode!=RESULT_OK) return;
+		String cim = data.getStringExtra(G.idCIM);
+		String txt = data.getStringExtra(G.idTXT);
+		if (cim==null||txt==null) return;
+		DiaItem dact = DiaItem.getByPos(actitem);
+		DiaItem dnew = new DiaItem(DiaItem.ditTXT);
+		dnew.mKnev=cim;
+		dnew.mTxt=txt.split("\n");
+		dnew.InsertMe(dact);
+		mLstAdapter.notifyDataSetChanged();
+		mLst.invalidate();
+	}
+
+	private void reqEdManual(int resultCode, Intent data) {
+		if (resultCode!=RESULT_OK) return;
+		DiaItem d = DiaItem.getByPos(actitem);
+		if (d==null) return;
+		String cim = data.getStringExtra(G.idCIM);
+		String txt = data.getStringExtra(G.idTXT);
+		if (cim==null||txt==null) return;
+		d.mKnev=cim;
+		d.mTxt=txt.split("\n");
+		mLstAdapter.notifyDataSetChanged();
+	}
 	
 	private void reqFilesave(int resultCode, Intent data) {
 		if (resultCode!=RESULT_OK) return;
@@ -298,7 +328,6 @@ public class EditActivity extends Activity
 		PopupMenu pm = new PopupMenu(this,v);
 		pm.inflate(R.menu.edaddmenu);
 		pm.setOnMenuItemClickListener(this);
-		pm.getMenu().findItem(R.id.mnEdAddManual).setVisible(false);
 		pm.show();
 		return true;
 	}
@@ -330,6 +359,13 @@ public class EditActivity extends Activity
 			it.putExtra(G.idFNAME,d.mVnev);
 			it.putExtra(G.idINDEX,p);
 			startActivityForResult(it,REQUEST_ED_PIC);
+			return;
+		}
+		if (d.mTipus== DiaItem.ditTXT) {
+			Intent it = new Intent(this,EdManualText.class);
+			it.putExtra(G.idCIM,d.mKnev);
+			it.putExtra(G.idTXT,String.join("\n",d.mTxt));
+			startActivityForResult(it,REQUEST_ED_MANUAL);
 			return;
 		}
 	}

--- a/Diatar/src/main/java/diatar/eu/G.java
+++ b/Diatar/src/main/java/diatar/eu/G.java
@@ -41,6 +41,7 @@ public class G  //globals
 	public static final String idUSEAKKORD = "UseAkkord";
 	public static final String idUSEKOTTA = "UseKotta";
 	public static final String idUSETITLE = "UseTitle";
+	public static final String idCIM = "cim";
 	public static final String idTXT = "txt";
 	public static final String idSEL = "sel";
 	public static final String idFTYPE = "FileType";

--- a/Diatar/src/main/java/diatar/eu/MainActivity.java
+++ b/Diatar/src/main/java/diatar/eu/MainActivity.java
@@ -274,9 +274,12 @@ public class MainActivity extends MainMenu
 		} else {
 			String title="";
 			String arr[]=null;
-			if (d==null || d.mTipus==d.ditDTX || d.mTipus==d.ditTXT) {
-				title=Dtx.getDiaTitle(this,kx-1,ex,vx);
-				arr=getDiaTxt(PageIdx);
+			if (d == null || d.mTipus == DiaItem.ditDTX) {
+				title = Dtx.getDiaTitle(this, kx - 1, ex, vx);
+				arr = getDiaTxt(PageIdx);
+			} else if (d.mTipus == DiaItem.ditTXT) {
+				title = d.getDiaTitle(false);
+				arr = getDiaTxt(PageIdx);
 			}
 			RecText rt = RecText.Create(title,arr);
 			rec=rt; rtyp=RecHdr.itText;

--- a/Diatar/src/main/res/layout/edmanualtext.xml
+++ b/Diatar/src/main/res/layout/edmanualtext.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="fill_parent"
+	android:layout_height="fill_parent"
+	android:orientation="vertical">
+
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:orientation="horizontal">
+
+		<TextView
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:labelFor="@id/edManualTextCim"
+			android:text="Cím:" />
+
+		<EditText
+			android:id="@+id/edManualTextCim"
+			android:layout_width="0dp"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:ems="10"
+			android:inputType="text" />
+	</LinearLayout>
+
+	<EditText
+		android:id="@+id/edManualTextSzoveg"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:ems="10"
+		android:gravity="start|top"
+		android:hint="Dia szövege..."
+		android:inputType="text|textAutoCorrect|textMultiLine"
+		android:lines="5"
+		android:singleLine="false" />
+
+	<LinearLayout
+		android:layout_height="wrap_content"
+		style="?android:attr/buttonBarStyle"
+		android:layout_width="match_parent"
+		android:orientation="horizontal">
+
+		<Button
+			android:layout_height="wrap_content"
+			style="?android:attr/buttonBarButtonStyle"
+			android:text="Mégse"
+			android:layout_width="wrap_content"
+			android:layout_weight="1.0"
+			android:onClick="onCancel"/>
+
+		<Button
+			android:layout_height="wrap_content"
+			style="?android:attr/buttonBarButtonStyle"
+			android:text="Ok"
+			android:layout_width="wrap_content"
+			android:layout_weight="1.0"
+			android:onClick="onOk"/>
+
+	</LinearLayout>
+
+</LinearLayout>
+


### PR DESCRIPTION
Az androidos verzióban jelenleg nem lehet egyéni szövegű diákat létrehozni. Ez a módosítás ezt a funkciót valósítja meg. Továbbá kijavítottam kisebb hibákat:
- egyéni szövegű dia mentésénél a sorok számozása 1-gyel kezdődött 0 helyett
- egyéni szövegű dia vetítésekor a dia címe nem jelent meg